### PR TITLE
Localize strings for i18n

### DIFF
--- a/includes/admin-dashboard.php
+++ b/includes/admin-dashboard.php
@@ -3,8 +3,8 @@
 // 🔧 Aggiunge la voce di menu in admin
 add_action('admin_menu', function () {
     add_menu_page(
-        'CF7 AntiSpam',
-        'CF7 AntiSpam',
+        __('CF7 AntiSpam', 'digitalezen-cf7'),
+        __('CF7 AntiSpam', 'digitalezen-cf7'),
         'manage_options',
         'cf7-antispam',
         'dz_cf7_render_dashboard',

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -22,7 +22,7 @@ function dz_cf7_anti_spam_guard($cf7) {
 
     if ($submitted_token !== $valid_token_now && $submitted_token !== $valid_token_prev) {
         dz_cf7_log_spam('token_scaduto', $data, $log_path);
-        $submission->set_response('⏳ Sessione scaduta. Ricarica la pagina e riprova.');
+        $submission->set_response(__('⏳ Sessione scaduta. Ricarica la pagina e riprova.', 'digitalezen-cf7'));
         $cf7->skip_mail = true;
         return;
     }
@@ -99,7 +99,7 @@ add_filter('wpcf7_validate', function($result, $tags) {
     $t0 = strtotime($data['timestamp'] ?? 'now');
     $t1 = time();
     if (($t1 - $t0) < 4) {
-        $result->invalidate('*', 'Per favore, non inviare troppo velocemente.');
+        $result->invalidate('*', __('Per favore, non inviare troppo velocemente.', 'digitalezen-cf7'));
     }
     return $result;
 }, 10, 2);

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -11,20 +11,24 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 ?>
 
 <div class="wrap" style="max-width: 800px;">
-    <h1 style="margin-bottom: 0;">🛡️ DigitaleZen CF7 AntiSpam Shield</h1>
-    <p style="margin-top: 4px;">Protezione intelligente per Contact Form 7</p>
+    <h1 style="margin-bottom: 0;">
+        <?php echo esc_html__('🛡️ DigitaleZen CF7 AntiSpam Shield', 'digitalezen-cf7'); ?>
+    </h1>
+    <p style="margin-top: 4px;">
+        <?php echo esc_html__('Protezione intelligente per Contact Form 7', 'digitalezen-cf7'); ?>
+    </p>
 
     <hr>
 
     <form method="POST">
         <?php wp_nonce_field('dz_cf7_save_settings'); ?>
 
-        <h2>📬 Impostazioni email report</h2>
-        <p>Ogni lunedì alle 2:00 verrà inviato il report dei tentativi di spam bloccati.</p>
+        <h2><?php esc_html_e('📬 Impostazioni email report', 'digitalezen-cf7'); ?></h2>
+        <p><?php echo esc_html__('Ogni lunedì alle 2:00 verrà inviato il report dei tentativi di spam bloccati.', 'digitalezen-cf7'); ?></p>
 
         <table class="form-table">
             <tr>
-                <th scope="row"><label for="dz_cf7_log_email">Email di destinazione</label></th>
+                <th scope="row"><label for="dz_cf7_log_email"><?php echo esc_html__('Email di destinazione', 'digitalezen-cf7'); ?></label></th>
                 <td>
                     <input type="email" id="dz_cf7_log_email" name="dz_cf7_log_email" value="<?php echo esc_attr($log_email); ?>" class="regular-text">
                 </td>
@@ -32,13 +36,13 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
         </table>
 
         <p>
-            <input type="submit" name="dz_cf7_settings_submit" class="button button-primary" value="Salva impostazioni">
+            <input type="submit" name="dz_cf7_settings_submit" class="button button-primary" value="<?php esc_attr_e('Salva impostazioni', 'digitalezen-cf7'); ?>">
         </p>
     </form>
 
     <hr>
 
-    <h2>🔧 Shortcode da inserire nei tuoi form CF7</h2>
+    <h2><?php esc_html_e('🔧 Shortcode da inserire nei tuoi form CF7', 'digitalezen-cf7'); ?></h2>
     <ul style="margin-left: 1em;">
         <li><code>[honeypot spamcheck]</code></li>
         <li><code>[hidden timestamp default:get]</code></li>
@@ -47,55 +51,55 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 
     <hr>
 
-    <h2>📁 File generati dal plugin</h2>
+    <h2><?php esc_html_e('📁 File generati dal plugin', 'digitalezen-cf7'); ?></h2>
     <table class="widefat striped" style="margin-bottom: 2em;">
         <thead>
             <tr>
-                <th>File</th>
-                <th>Descrizione</th>
-                <th>Azioni</th>
+                <th><?php esc_html_e('File', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('Descrizione', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('Azioni', 'digitalezen-cf7'); ?></th>
             </tr>
         </thead>
         <tbody>
             <tr>
                 <td><code>cf7-spam-log.csv</code></td>
-                <td>Log dei tentativi bloccati (data, email, IP, motivo, trigger)</td>
+                <td><?php echo esc_html__('Log dei tentativi bloccati (data, email, IP, motivo, trigger)', 'digitalezen-cf7'); ?></td>
                 <td>
-                    <a href="<?php echo esc_url($log_file); ?>" class="button button-secondary" download>📥 Download</a>
+                    <a href="<?php echo esc_url($log_file); ?>" class="button button-secondary" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
                 </td>
             </tr>
             <tr>
                 <td><code>cf7-blacklist.json</code></td>
-                <td>Blacklist aggiornata da App Script (IP, email, domini, ecc.)</td>
+                <td><?php echo esc_html__('Blacklist aggiornata da App Script (IP, email, domini, ecc.)', 'digitalezen-cf7'); ?></td>
                 <td>
                     <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=cf7-blacklist.json')); ?>"
-                             class="button button-secondary" target="_blank">👁️ Visualizza</a>
-                    <a href="<?php echo esc_url($blacklist_file); ?>" class="button" download>📥 Download</a>
+                             class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
+                    <a href="<?php echo esc_url($blacklist_file); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
                 </td>
             </tr>
             <tr>
                 <td><code>block-ip.txt</code></td>
-                <td>IP bloccati temporaneamente (blocco soft, durata 10 minuti)</td>
+                <td><?php echo esc_html__('IP bloccati temporaneamente (blocco soft, durata 10 minuti)', 'digitalezen-cf7'); ?></td>
                 <td>
-                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button button-secondary" target="_blank">👁️ Visualizza</a>
-                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button" download>📥 Download</a>
+                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
+                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
                 </td>
             </tr>
             <tr>
                 <td><code>ip-attempts.json</code></td>
-                <td>Storico tentativi spam per IP</td>
+                <td><?php echo esc_html__('Storico tentativi spam per IP', 'digitalezen-cf7'); ?></td>
                 <td>
-                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ Visualizza</a>
+                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
 
-                    <a href="<?php echo esc_url(content_url('/ip-attempts.json')); ?>" class="button" download>📥 Download</a>
+                    <a href="<?php echo esc_url(content_url('/ip-attempts.json')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
                 </td>
             </tr>
             <tr>
                 <td><code>email-attempts.json</code></td>
-                <td>Storico tentativi spam per email</td>
+                <td><?php echo esc_html__('Storico tentativi spam per email', 'digitalezen-cf7'); ?></td>
                 <td>
-                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ Visualizza</a>
-                    <a href="<?php echo esc_url(content_url('/email-attempts.json')); ?>" class="button" download>📥 Download</a>
+                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
+                    <a href="<?php echo esc_url(content_url('/email-attempts.json')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
                 </td>
             </tr>
         </tbody>
@@ -104,7 +108,7 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 
     <hr>
 
-    <h2>📊 Report spam bloccati (dati reali)</h2>
+    <h2><?php esc_html_e('📊 Report spam bloccati (dati reali)', 'digitalezen-cf7'); ?></h2>
 
     <canvas id="dz-cf7-chart" height="100" style="margin-bottom: 2em;"></canvas>
 
@@ -130,11 +134,11 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 
     // Calcolo i blocchi per ogni intervallo
     $data_report = [
-        '24h' => dz_cf7_count_spam_by_range(1440),
-        '7 giorni' => dz_cf7_count_spam_by_range(10080),
-        '28 giorni' => dz_cf7_count_spam_by_range(40320),
-        '3 mesi' => dz_cf7_count_spam_by_range(129600),
-        '1 anno' => dz_cf7_count_spam_by_range(525600),
+        esc_html__('24h', 'digitalezen-cf7')      => dz_cf7_count_spam_by_range(1440),
+        esc_html__('7 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(10080),
+        esc_html__('28 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(40320),
+        esc_html__('3 mesi', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(129600),
+        esc_html__('1 anno', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(525600),
     ];
 
     // Passaggio dati a JS
@@ -142,15 +146,15 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
     echo '<script>window.dz_cf7_chart_labels = ' . json_encode(array_keys($data_report)) . ';</script>';
     ?>
 
-    <h3>🧾 Ultimi tentativi bloccati</h3>
+    <h3><?php esc_html_e('🧾 Ultimi tentativi bloccati', 'digitalezen-cf7'); ?></h3>
     <table class="widefat striped" style="max-width: 100%; margin-top: 1em;">
         <thead>
             <tr>
-                <th>Data</th>
-                <th>Email</th>
-                <th>IP</th>
-                <th>Motivo</th>
-                <th>Trigger</th>
+                <th><?php esc_html_e('Data', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('Email', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('IP', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('Motivo', 'digitalezen-cf7'); ?></th>
+                <th><?php esc_html_e('Trigger', 'digitalezen-cf7'); ?></th>
             </tr>
         </thead>
         <tbody>
@@ -177,7 +181,7 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 
     <p style="margin-top: 2em; text-align: center; color: #666;">
         <small>
-            Powered by <a href="https://digitalezen.it" target="_blank" style="text-decoration: none;">DigitaleZen.it</a> 🚀
+            <?php echo wp_kses_post(__('Powered by <a href="https://digitalezen.it" target="_blank" style="text-decoration: none;">DigitaleZen.it</a> 🚀', 'digitalezen-cf7')); ?>
         </small>
     </p>
 


### PR DESCRIPTION
## Summary
- localize admin menu name
- escape and translate dashboard text
- wrap validation messages for translation

## Testing
- `php -l includes/admin-dashboard.php` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598944aa2c8326a1c8e1126ce53796