### PR TITLE
Fix PHPCS issues and headers

### DIFF
--- a/digitalezen-cf7-antispam.php
+++ b/digitalezen-cf7-antispam.php
@@ -1,6 +1,9 @@
 <?php
 /**
+ * File Name: digitalezen-cf7-antispam.php
  * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
  * Description: Protezione avanzata contro lo spam per Contact Form 7. Blacklist, logging, flood control, dashboard elegante.
  * Version: 1.0.0
  * Author: DigitaleZen
@@ -24,8 +27,8 @@ require_once DZ_CF7_DIR . 'includes/admin-dashboard.php';
 
 // Carica assets per l’admin
 add_action('admin_enqueue_scripts', function($hook) {
-    if (strpos($hook, 'cf7-antispam') !== false) {
-        wp_enqueue_style('dz-cf7-style', DZ_CF7_URL . 'assets/style.css');
-        wp_enqueue_script('dz-cf7-script', DZ_CF7_URL . 'assets/script.js', [], false, true);
-    }
+	if (strpos($hook, 'cf7-antispam') !== false) {
+	    wp_enqueue_style('dz-cf7-style', DZ_CF7_URL . 'assets/style.css');
+	    wp_enqueue_script('dz-cf7-script', DZ_CF7_URL . 'assets/script.js', [], false, true);
+	}
 });

--- a/includes/admin-dashboard.php
+++ b/includes/admin-dashboard.php
@@ -1,36 +1,47 @@
 <?php
+/**
+ * File Name: admin-dashboard.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
 
 // 🔧 Aggiunge la voce di menu in admin
 add_action('admin_menu', function () {
-    add_menu_page(
-        __('CF7 AntiSpam', 'digitalezen-cf7'),
-        __('CF7 AntiSpam', 'digitalezen-cf7'),
-        'manage_options',
-        'cf7-antispam',
-        'dz_cf7_render_dashboard',
-        'dashicons-shield-alt',
-        80
-    );
+	add_menu_page(
+	    __('CF7 AntiSpam', 'digitalezen-cf7'),
+	    __('CF7 AntiSpam', 'digitalezen-cf7'),
+	    'manage_options',
+	    'cf7-antispam',
+	    'dz_cf7_render_dashboard',
+	    'dashicons-shield-alt',
+	    80
+	);
 });
 
 // 💾 Salva le impostazioni dal form
 add_action('admin_init', function () {
-    if (isset($_POST['dz_cf7_settings_submit']) && check_admin_referer('dz_cf7_save_settings')) {
-        $email = sanitize_email($_POST['dz_cf7_log_email'] ?? '');
-        if (is_email($email)) {
-            update_option('dz_cf7_log_email', $email);
-        }
-    }
+	if (isset($_POST['dz_cf7_settings_submit']) && check_admin_referer('dz_cf7_save_settings')) {
+	    $email = sanitize_email($_POST['dz_cf7_log_email'] ?? '');
+	    if (is_email($email)) {
+	        update_option('dz_cf7_log_email', $email);
+	    }
+	}
 });
 
 // 📄 Mostra la dashboard (carica template)
-function dz_cf7_render_dashboard() {
-    include DZ_CF7_DIR . 'templates/dashboard.php';
+function dz_cf7_render_dashboard()
+{
+	include DZ_CF7_DIR . 'templates/dashboard.php';
 }
 
 add_action('admin_init', function () {
-    if (isset($_GET['action']) && $_GET['action'] === 'dz_cf7_view_json' && isset($_GET['f'])) {
-        include_once DZ_CF7_DIR . 'includes/view-json.php';
-        exit;
-    }
+	$action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : '';
+	$file   = isset($_GET['f']) ? sanitize_text_field($_GET['f']) : '';
+
+	if ($action === 'dz_cf7_view_json' && $file) {
+	    $_GET['f'] = $file;
+	    include_once DZ_CF7_DIR . 'includes/view-json.php';
+	    exit;
+	}
 });

--- a/includes/api-fetcher.php
+++ b/includes/api-fetcher.php
@@ -1,32 +1,40 @@
 <?php
+/**
+ * File Name: api-fetcher.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
 
 // 🔁 Scarica la blacklist da Google Apps Script
-function dz_cf7_update_blacklist_json() {
-    $url = 'https://script.google.com/macros/s/AKfycbzTI7i_j2D7oe70RKcPDY0iT_meqSh_-RhQsPzQvdDhDUe8IiJhD4OdExWMgwpKM8r5/exec';
+function dz_cf7_update_blacklist_json()
+{
+	$url = 'https://script.google.com/macros/s/AKfycbzTI7i_j2D7oe70RKcPDY0iT_meq'
+	    . 'Sh_-RhQsPzQvdDhDUe8IiJhD4OdExWMgwpKM8r5/exec';
 
-    $upload_dir = wp_upload_dir()['basedir'] . '/cf7-logs';
-    $path = $upload_dir . '/cf7-blacklist.json';
+	$upload_dir = wp_upload_dir()['basedir'] . '/cf7-logs';
+	$path = $upload_dir . '/cf7-blacklist.json';
 
-    // Crea directory se non esiste
-    if (!file_exists($upload_dir)) {
-        wp_mkdir_p($upload_dir);
-    }
+	// Crea directory se non esiste
+	if (!file_exists($upload_dir)) {
+	    wp_mkdir_p($upload_dir);
+	}
 
-    // Effettua richiesta remota
-    $res = wp_remote_get($url);
-    if (is_wp_error($res)) return;
+	// Effettua richiesta remota
+	$res = wp_remote_get($url);
+	if (is_wp_error($res)) return;
 
-    $json = json_decode(wp_remote_retrieve_body($res), true);
+	$json = json_decode(wp_remote_retrieve_body($res), true);
 
-    // Se valido → salva il file
-    if (is_array($json)) {
-        file_put_contents($path, json_encode($json));
-    }
+	// Se valido → salva il file
+	if (is_array($json)) {
+	    file_put_contents($path, json_encode($json));
+	}
 }
 
 // 🔁 Hook pianificazione CRON
 add_action('dz_cf7_blacklist_daily', 'dz_cf7_update_blacklist_json');
 
 if (!wp_next_scheduled('dz_cf7_blacklist_daily')) {
-    wp_schedule_event(time(), 'daily', 'dz_cf7_blacklist_daily');
+	wp_schedule_event(time(), 'daily', 'dz_cf7_blacklist_daily');
 }

--- a/includes/firewall.php
+++ b/includes/firewall.php
@@ -1,29 +1,36 @@
 <?php
+/**
+ * File Name: firewall.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
+
 // 🔒 BLOCCO IP – Hook INIT
 add_action('init', function () {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $file = WP_CONTENT_DIR . '/block-ip.txt';
+	$ip  = sanitize_text_field($_SERVER['REMOTE_ADDR'] ?? '');
+	$file = WP_CONTENT_DIR . '/block-ip.txt';
 
-    if (!file_exists($file)) return;
+	if (!file_exists($file)) return;
 
-    $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-    $new_lines = [];
+	$lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	$new_lines = [];
 
-    foreach ($lines as $line) {
-        list($blocked_ip, $until) = explode('|', $line);
+	foreach ($lines as $line) {
+	    list($blocked_ip, $until) = explode('|', $line);
 
-        // Mantieni solo le righe valide (non scadute)
-        if (time() < intval($until)) {
-            $new_lines[] = "$blocked_ip|$until";
+	    // Mantieni solo le righe valide (non scadute)
+	    if (time() < intval($until)) {
+	        $new_lines[] = "$blocked_ip|$until";
 
-            // Se l'IP corrente è bloccato → fermalo
-            if ($ip === $blocked_ip) {
-                header('HTTP/1.1 403 Forbidden');
-                exit('⛔ Accesso temporaneamente bloccato per comportamento sospetto.');
-            }
-        }
-    }
+	        // Se l'IP corrente è bloccato → fermalo
+	        if ($ip === $blocked_ip) {
+	            header('HTTP/1.1 403 Forbidden');
+	            exit(esc_html__('⛔ Accesso temporaneamente bloccato per comportamento sospetto.', 'digitalezen-cf7'));
+	        }
+	    }
+	}
 
-    // Sovrascrive il file con solo IP ancora validi
-    file_put_contents($file, implode("\n", $new_lines) . "\n");
+	// Sovrascrive il file con solo IP ancora validi
+	file_put_contents($file, implode("\n", $new_lines) . "\n");
 });

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -1,114 +1,121 @@
 <?php
+/**
+ * File Name: hooks.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
 
 // ✅ Hook principale: blocca invio se sospetto
 add_action('wpcf7_before_send_mail', 'dz_cf7_anti_spam_guard');
 
-function dz_cf7_anti_spam_guard($cf7) {
-    $submission = WPCF7_Submission::get_instance();
-    if (!$submission) return;
+function dz_cf7_anti_spam_guard($cf7)
+{
+	$submission = WPCF7_Submission::get_instance();
+	if (!$submission) return;
 
-    $data = $submission->get_posted_data();
-    $upload_dir = wp_upload_dir()['basedir'] . '/cf7-logs';
-    $log_path = $upload_dir . '/cf7-spam-log.csv';
-    $json_path = $upload_dir . '/cf7-blacklist.json';
+	$data = $submission->get_posted_data();
+	$upload_dir = wp_upload_dir()['basedir'] . '/cf7-logs';
+	$log_path = $upload_dir . '/cf7-spam-log.csv';
+	$json_path = $upload_dir . '/cf7-blacklist.json';
 
-    // 🧪 Token form anti-bot
-    $form_id = $cf7->id();
-    $hour_now = date('YmdH');
-    $hour_prev = date('YmdH', strtotime('-1 hour'));
-    $valid_token_now = hash('sha256', "form-$form_id::$hour_now");
-    $valid_token_prev = hash('sha256', "form-$form_id::$hour_prev");
-    $submitted_token = $data['form-token'] ?? '';
+	// 🧪 Token form anti-bot
+	$form_id = $cf7->id();
+	$hour_now = date('YmdH');
+	$hour_prev = date('YmdH', strtotime('-1 hour'));
+	$valid_token_now = hash('sha256', "form-$form_id::$hour_now");
+	$valid_token_prev = hash('sha256', "form-$form_id::$hour_prev");
+	$submitted_token = $data['form-token'] ?? '';
 
-    if ($submitted_token !== $valid_token_now && $submitted_token !== $valid_token_prev) {
-        dz_cf7_log_spam('token_scaduto', $data, $log_path);
-        $submission->set_response(__('⏳ Sessione scaduta. Ricarica la pagina e riprova.', 'digitalezen-cf7'));
-        $cf7->skip_mail = true;
-        return;
-    }
+	if ($submitted_token !== $valid_token_now && $submitted_token !== $valid_token_prev) {
+	    dz_cf7_log_spam('token_scaduto', $data, $log_path);
+	    $submission->set_response(__('⏳ Sessione scaduta. Ricarica la pagina e riprova.', 'digitalezen-cf7'));
+	    $cf7->skip_mail = true;
+	    return;
+	}
 
-    // 🕳️ Honeypot
-    if (!empty($data['spamcheck'])) {
-        dz_cf7_log_spam('honeypot', $data, $log_path);
-        $cf7->skip_mail = true;
-        return;
-    }
+	// 🕳️ Honeypot
+	if (!empty($data['spamcheck'])) {
+	    dz_cf7_log_spam('honeypot', $data, $log_path);
+	    $cf7->skip_mail = true;
+	    return;
+	}
 
-    // 🔍 Controlli da blacklist
-    if (!file_exists($json_path)) return;
-    $json = json_decode(file_get_contents($json_path), true);
-    if (!$json || !is_array($json)) return;
+	// 🔍 Controlli da blacklist
+	if (!file_exists($json_path)) return;
+	$json = json_decode(file_get_contents($json_path), true);
+	if (!$json || !is_array($json)) return;
 
-    $blocked_ips = $json['ips'] ?? [];
-    $blocked_emails = $json['emails'] ?? [];
-    $blocked_domains = $json['domains'] ?? [];
-    $blocked_usernames = $json['usernames'] ?? [];
-    $blocked_keywords = $json['keywords'] ?? [];
+	$blocked_ips = $json['ips'] ?? [];
+	$blocked_emails = $json['emails'] ?? [];
+	$blocked_domains = $json['domains'] ?? [];
+	$blocked_usernames = $json['usernames'] ?? [];
+	$blocked_keywords = $json['keywords'] ?? [];
 
-    $client_ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $email = $data['your-email'] ?? '';
-    $domain = ($email && strpos($email, '@') !== false) ? strtolower(substr(strrchr($email, "@"), 1)) : '';
+	$client_ip = sanitize_text_field($_SERVER['REMOTE_ADDR'] ?? '');
+	$email     = sanitize_email($data['your-email'] ?? '');
+	$domain = ($email && strpos($email, '@') !== false) ? strtolower(substr(strrchr($email, "@"), 1)) : '';
 
-    if (in_array($client_ip, $blocked_ips)) {
-        dz_cf7_log_spam('ip', $data, $log_path, $client_ip);
-        $cf7->skip_mail = true;
-        return;
-    }
-    if (in_array($email, $blocked_emails)) {
-        dz_cf7_log_spam('email', $data, $log_path, $email);
-        $cf7->skip_mail = true;
-        return;
-    }
-    if (in_array($domain, $blocked_domains)) {
-        dz_cf7_log_spam('domain', $data, $log_path, $domain);
-        $cf7->skip_mail = true;
-        return;
-    }
+	if (in_array($client_ip, $blocked_ips)) {
+	    dz_cf7_log_spam('ip', $data, $log_path, $client_ip);
+	    $cf7->skip_mail = true;
+	    return;
+	}
+	if (in_array($email, $blocked_emails)) {
+	    dz_cf7_log_spam('email', $data, $log_path, $email);
+	    $cf7->skip_mail = true;
+	    return;
+	}
+	if (in_array($domain, $blocked_domains)) {
+	    dz_cf7_log_spam('domain', $data, $log_path, $domain);
+	    $cf7->skip_mail = true;
+	    return;
+	}
 
-    foreach ($data as $value) {
-        foreach ($blocked_usernames as $username) {
-            if (stripos($value, $username) !== false) {
-                dz_cf7_log_spam('username', $data, $log_path, $username);
-                $cf7->skip_mail = true;
-                return;
-            }
-        }
-        foreach ($blocked_keywords as $keyword) {
-            if (stripos($value, $keyword) !== false) {
-                dz_cf7_log_spam('keyword', $data, $log_path, $keyword);
-                $cf7->skip_mail = true;
-                return;
-            }
-        }
-    }
+	foreach ($data as $value) {
+	    foreach ($blocked_usernames as $username) {
+	        if (stripos($value, $username) !== false) {
+	            dz_cf7_log_spam('username', $data, $log_path, $username);
+	            $cf7->skip_mail = true;
+	            return;
+	        }
+	    }
+	    foreach ($blocked_keywords as $keyword) {
+	        if (stripos($value, $keyword) !== false) {
+	            dz_cf7_log_spam('keyword', $data, $log_path, $keyword);
+	            $cf7->skip_mail = true;
+	            return;
+	        }
+	    }
+	}
 
-    // 🔥 Flood protection
-    if (dz_cf7_check_flood($client_ip, $email)) {
-        dz_cf7_log_spam('flood', $data, $log_path, "$client_ip/$email");
-        $cf7->skip_mail = true;
-        return;
-    }
+	// 🔥 Flood protection
+	if (dz_cf7_check_flood($client_ip, $email)) {
+	    dz_cf7_log_spam('flood', $data, $log_path, "$client_ip/$email");
+	    $cf7->skip_mail = true;
+	    return;
+	}
 }
 
 // 🐌 Controlla tempo di invio (almeno 4s)
 add_filter('wpcf7_validate', function($result, $tags) {
-    $submission = WPCF7_Submission::get_instance();
-    if (!$submission) return $result;
-    $data = $submission->get_posted_data();
+	$submission = WPCF7_Submission::get_instance();
+	if (!$submission) return $result;
+	$data = $submission->get_posted_data();
 
-    $t0 = strtotime($data['timestamp'] ?? 'now');
-    $t1 = time();
-    if (($t1 - $t0) < 4) {
-        $result->invalidate('*', __('Per favore, non inviare troppo velocemente.', 'digitalezen-cf7'));
-    }
-    return $result;
+	$t0 = strtotime($data['timestamp'] ?? 'now');
+	$t1 = time();
+	if (($t1 - $t0) < 4) {
+	    $result->invalidate('*', __('Per favore, non inviare troppo velocemente.', 'digitalezen-cf7'));
+	}
+	return $result;
 }, 10, 2);
 
 // 🔐 Genera token invisibile [form-token]
 add_filter('wpcf7_form_hidden_fields', function($hidden_fields, $instance) {
-    $form_id = $instance->id();
-    $hour = date('YmdH');
-    $token = hash('sha256', "form-$form_id::$hour");
-    $hidden_fields['form-token'] = $token;
-    return $hidden_fields;
+	$form_id = $instance->id();
+	$hour = date('YmdH');
+	$token = hash('sha256', "form-$form_id::$hour");
+	$hidden_fields['form-token'] = $token;
+	return $hidden_fields;
 }, 10, 2);

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -1,86 +1,99 @@
 <?php
+/**
+ * File Name: logger.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
 
 // 📦 Logging CSV + IP/email tracking
-function dz_cf7_log_spam($reason, $data, $log_path, $trigger = '') {
-    $dir = dirname($log_path);
-    if (!file_exists($dir)) wp_mkdir_p($dir);
+function dz_cf7_log_spam($reason, $data, $log_path, $trigger = '')
+{
+	$dir = dirname($log_path);
+	if (!file_exists($dir)) {
+	    wp_mkdir_p($dir);
+	}
 
-    $email = $data['your-email'] ?? 'unknown';
-    $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-    $row = [date('Y-m-d H:i:s'), $email, $ip, $reason, $trigger];
-    $line = implode(',', array_map('dz_cf7_csv_escape', $row)) . "\n";
-    file_put_contents($log_path, $line, FILE_APPEND);
+	$email = sanitize_email($data['your-email'] ?? 'unknown');
+	$ip    = sanitize_text_field($_SERVER['REMOTE_ADDR'] ?? 'unknown');
+	$row = [date('Y-m-d H:i:s'), $email, $ip, $reason, $trigger];
+	$line = implode(',', array_map('dz_cf7_csv_escape', $row)) . "\n";
+	file_put_contents($log_path, $line, FILE_APPEND);
 
-    // Blocco IP temporaneo
-    $blockfile = WP_CONTENT_DIR . '/block-ip.txt';
-    $block_until = time() + 600; // 10 minuti
-    file_put_contents($blockfile, "$ip|$block_until\n", FILE_APPEND);
+	// Blocco IP temporaneo
+	$blockfile = WP_CONTENT_DIR . '/block-ip.txt';
+	$block_until = time() + 600; // 10 minuti
+	file_put_contents($blockfile, "$ip|$block_until\n", FILE_APPEND);
 
-    dz_cf7_track_attempts($ip, $email);
+	dz_cf7_track_attempts($ip, $email);
 }
 
-function dz_cf7_csv_escape($value) {
-    return '"' . str_replace('"', '""', $value) . '"';
+function dz_cf7_csv_escape($value)
+{
+	return '"' . str_replace('"', '""', $value) . '"';
 }
 
 // 👁️‍🗨️ Flood detection IP/email
-function dz_cf7_check_flood($ip, $email) {
-    $window = 900; // 15 minuti
-    $limit = 3;
+function dz_cf7_check_flood($ip, $email)
+{
+	$window = 900; // 15 minuti
+	$limit = 3;
 
-    $ip_path = WP_CONTENT_DIR . '/ip-attempts.json';
-    $mail_path = WP_CONTENT_DIR . '/email-attempts.json';
+	$ip_path = WP_CONTENT_DIR . '/ip-attempts.json';
+	$mail_path = WP_CONTENT_DIR . '/email-attempts.json';
 
-    $ip_attempts = file_exists($ip_path) ? json_decode(file_get_contents($ip_path), true) ?? [] : [];
-    $mail_attempts = file_exists($mail_path) ? json_decode(file_get_contents($mail_path), true) ?? [] : [];
+	$ip_attempts = file_exists($ip_path) ? json_decode(file_get_contents($ip_path), true) ?? [] : [];
+	$mail_attempts = file_exists($mail_path) ? json_decode(file_get_contents($mail_path), true) ?? [] : [];
 
-    $now = time();
+	$now = time();
 
-    $ip_attempts[$ip] = array_filter($ip_attempts[$ip] ?? [], fn($ts) => ($now - $ts) < $window);
-    $ip_attempts[$ip][] = $now;
+	$ip_attempts[$ip] = array_filter($ip_attempts[$ip] ?? [], fn($ts) => ($now - $ts) < $window);
+	$ip_attempts[$ip][] = $now;
 
-    $mail_attempts[$email] = array_filter($mail_attempts[$email] ?? [], fn($ts) => ($now - $ts) < $window);
-    $mail_attempts[$email][] = $now;
+	$mail_attempts[$email] = array_filter($mail_attempts[$email] ?? [], fn($ts) => ($now - $ts) < $window);
+	$mail_attempts[$email][] = $now;
 
-    file_put_contents($ip_path, json_encode($ip_attempts));
-    file_put_contents($mail_path, json_encode($mail_attempts));
+	file_put_contents($ip_path, json_encode($ip_attempts));
+	file_put_contents($mail_path, json_encode($mail_attempts));
 
-    return (count($ip_attempts[$ip]) >= $limit || count($mail_attempts[$email]) >= $limit);
+	return (count($ip_attempts[$ip]) >= $limit || count($mail_attempts[$email]) >= $limit);
 }
 
-function dz_cf7_track_attempts($ip, $email) {
-    // Intenzionalmente vuoto: la funzione sopra fa tutto
+function dz_cf7_track_attempts($ip, $email)
+{
+	// Intenzionalmente vuoto: la funzione sopra fa tutto
 }
 
 // 📬 Invio settimanale CSV
 add_action('dz_cf7_send_log', 'dz_cf7_send_spam_log_email');
 
-function dz_cf7_send_spam_log_email() {
-    $path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
+function dz_cf7_send_spam_log_email()
+{
+	$path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
 
-    // Se il file non esiste o è vuoto, non inviare nulla
-    if (!file_exists($path) || filesize($path) == 0) return;
+	// Se il file non esiste o è vuoto, non inviare nulla
+	if (!file_exists($path) || filesize($path) == 0) return;
 
-    // Recupera l'email dal campo personalizzato oppure usa quella dell'amministratore
-    $email_destinatario = get_option('dz_cf7_log_email');
-    if (empty($email_destinatario) || !is_email($email_destinatario)) {
-        $email_destinatario = get_option('admin_email');
-    }
+	// Recupera l'email dal campo personalizzato oppure usa quella dell'amministratore
+	$email_destinatario = get_option('dz_cf7_log_email');
+	if (empty($email_destinatario) || !is_email($email_destinatario)) {
+	    $email_destinatario = get_option('admin_email');
+	}
 
-    // Invia email con allegato
-    wp_mail(
-        $email_destinatario,
-        'Report settimanale CF7 - Spam bloccato',
-        'In allegato il file con i tentativi bloccati tramite il filtro anti-spam.',
-        ['Content-Type: text/plain; charset=UTF-8'],
-        [$path]
-    );
+	// Invia email con allegato
+	wp_mail(
+	    $email_destinatario,
+	    __('Report settimanale CF7 - Spam bloccato', 'digitalezen-cf7'),
+	    __('In allegato il file con i tentativi bloccati tramite il filtro anti-spam.', 'digitalezen-cf7'),
+	    ['Content-Type: text/plain; charset=UTF-8'],
+	    [$path]
+	);
 
-    // Svuota il file dopo l'invio
-    file_put_contents($path, '');
+	// Svuota il file dopo l'invio
+	file_put_contents($path, '');
 }
 
 // ⏰ Pianifica cron settimanale
 if (!wp_next_scheduled('dz_cf7_send_log')) {
-    wp_schedule_event(strtotime('next Monday 02:00'), 'weekly', 'dz_cf7_send_log');
+	wp_schedule_event(strtotime('next Monday 02:00'), 'weekly', 'dz_cf7_send_log');
 }

--- a/includes/view-json.php
+++ b/includes/view-json.php
@@ -1,22 +1,29 @@
 <?php
+/**
+ * File Name: view-json.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
+
 // Sicurezza: accetta solo nomi autorizzati
 $whitelist = [
-    'cf7-blacklist.json' => WP_CONTENT_DIR . '/uploads/cf7-logs/cf7-blacklist.json',
-    'ip-attempts.json'   => WP_CONTENT_DIR . '/ip-attempts.json',
-    'email-attempts.json'=> WP_CONTENT_DIR . '/email-attempts.json',
+	'cf7-blacklist.json' => WP_CONTENT_DIR . '/uploads/cf7-logs/cf7-blacklist.json',
+	'ip-attempts.json'   => WP_CONTENT_DIR . '/ip-attempts.json',
+	'email-attempts.json'=> WP_CONTENT_DIR . '/email-attempts.json',
 ];
 
-$file_key = $_GET['f'] ?? '';
+$file_key = isset($_GET['f']) ? sanitize_text_field($_GET['f']) : '';
 if (!isset($whitelist[$file_key])) {
-    http_response_code(403);
-    exit("⛔ Accesso non autorizzato.");
+	http_response_code(403);
+	exit(esc_html__('⛔ Accesso non autorizzato.', 'digitalezen-cf7'));
 }
 
 $file_path = $whitelist[$file_key];
 
 if (!file_exists($file_path)) {
-    http_response_code(404);
-    exit("❌ File non trovato.");
+	http_response_code(404);
+	exit(esc_html__('❌ File non trovato.', 'digitalezen-cf7'));
 }
 
 header("Content-Type: text/plain; charset=UTF-8");

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * File Name: dashboard.php
+ * Plugin Name: DigitaleZen CF7 AntiSpam Shield
+ * Autore: DigitaleZen
+ * Licenza: MIT
+ */
+
 // Sicurezza base
 if (!current_user_can('manage_options')) return;
 
@@ -11,179 +18,268 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 ?>
 
 <div class="wrap" style="max-width: 800px;">
-    <h1 style="margin-bottom: 0;">
-        <?php echo esc_html__('🛡️ DigitaleZen CF7 AntiSpam Shield', 'digitalezen-cf7'); ?>
-    </h1>
-    <p style="margin-top: 4px;">
-        <?php echo esc_html__('Protezione intelligente per Contact Form 7', 'digitalezen-cf7'); ?>
-    </p>
+	<h1 style="margin-bottom: 0;">
+	    <?php echo esc_html__('🛡️ DigitaleZen CF7 AntiSpam Shield', 'digitalezen-cf7'); ?>
+	</h1>
+	<p style="margin-top: 4px;">
+	    <?php echo esc_html__('Protezione intelligente per Contact Form 7', 'digitalezen-cf7'); ?>
+	</p>
 
-    <hr>
+	<hr>
 
-    <form method="POST">
-        <?php wp_nonce_field('dz_cf7_save_settings'); ?>
+	<form method="POST">
+	    <?php wp_nonce_field('dz_cf7_save_settings'); ?>
 
-        <h2><?php esc_html_e('📬 Impostazioni email report', 'digitalezen-cf7'); ?></h2>
-        <p><?php echo esc_html__('Ogni lunedì alle 2:00 verrà inviato il report dei tentativi di spam bloccati.', 'digitalezen-cf7'); ?></p>
+	    <h2><?php esc_html_e('📬 Impostazioni email report', 'digitalezen-cf7'); ?></h2>
+	    <p>
+	        <?php
+	        echo esc_html__(
+	            'Ogni lunedì alle 2:00 verrà inviato il report dei tentativi di spam bloccati.',
+	            'digitalezen-cf7'
+	        );
+	        ?>
+	    </p>
 
-        <table class="form-table">
-            <tr>
-                <th scope="row"><label for="dz_cf7_log_email"><?php echo esc_html__('Email di destinazione', 'digitalezen-cf7'); ?></label></th>
-                <td>
-                    <input type="email" id="dz_cf7_log_email" name="dz_cf7_log_email" value="<?php echo esc_attr($log_email); ?>" class="regular-text">
-                </td>
-            </tr>
-        </table>
+	    <table class="form-table">
+	        <tr>
+	            <th scope="row">
+	                <label for="dz_cf7_log_email">
+	                    <?php echo esc_html__('Email di destinazione', 'digitalezen-cf7'); ?>
+	                </label>
+	            </th>
+	            <td>
+	                <input type="email" id="dz_cf7_log_email" name="dz_cf7_log_email"
+	                       value="<?php echo esc_attr($log_email); ?>" class="regular-text">
+	            </td>
+	        </tr>
+	    </table>
 
-        <p>
-            <input type="submit" name="dz_cf7_settings_submit" class="button button-primary" value="<?php esc_attr_e('Salva impostazioni', 'digitalezen-cf7'); ?>">
-        </p>
-    </form>
+	    <p>
+	        <input type="submit" name="dz_cf7_settings_submit" class="button button-primary"
+	               value="<?php esc_attr_e('Salva impostazioni', 'digitalezen-cf7'); ?>">
+	    </p>
+	</form>
 
-    <hr>
+	<hr>
 
-    <h2><?php esc_html_e('🔧 Shortcode da inserire nei tuoi form CF7', 'digitalezen-cf7'); ?></h2>
-    <ul style="margin-left: 1em;">
-        <li><code>[honeypot spamcheck]</code></li>
-        <li><code>[hidden timestamp default:get]</code></li>
-        <li><code>[hidden form-token default:get]</code></li>
-    </ul>
+	<h2><?php esc_html_e('🔧 Shortcode da inserire nei tuoi form CF7', 'digitalezen-cf7'); ?></h2>
+	<ul style="margin-left: 1em;">
+	    <li><code>[honeypot spamcheck]</code></li>
+	    <li><code>[hidden timestamp default:get]</code></li>
+	    <li><code>[hidden form-token default:get]</code></li>
+	</ul>
 
-    <hr>
+	<hr>
 
-    <h2><?php esc_html_e('📁 File generati dal plugin', 'digitalezen-cf7'); ?></h2>
-    <table class="widefat striped" style="margin-bottom: 2em;">
-        <thead>
-            <tr>
-                <th><?php esc_html_e('File', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('Descrizione', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('Azioni', 'digitalezen-cf7'); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><code>cf7-spam-log.csv</code></td>
-                <td><?php echo esc_html__('Log dei tentativi bloccati (data, email, IP, motivo, trigger)', 'digitalezen-cf7'); ?></td>
-                <td>
-                    <a href="<?php echo esc_url($log_file); ?>" class="button button-secondary" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
-                </td>
-            </tr>
-            <tr>
-                <td><code>cf7-blacklist.json</code></td>
-                <td><?php echo esc_html__('Blacklist aggiornata da App Script (IP, email, domini, ecc.)', 'digitalezen-cf7'); ?></td>
-                <td>
-                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=cf7-blacklist.json')); ?>"
-                             class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
-                    <a href="<?php echo esc_url($blacklist_file); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
-                </td>
-            </tr>
-            <tr>
-                <td><code>block-ip.txt</code></td>
-                <td><?php echo esc_html__('IP bloccati temporaneamente (blocco soft, durata 10 minuti)', 'digitalezen-cf7'); ?></td>
-                <td>
-                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
-                    <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
-                </td>
-            </tr>
-            <tr>
-                <td><code>ip-attempts.json</code></td>
-                <td><?php echo esc_html__('Storico tentativi spam per IP', 'digitalezen-cf7'); ?></td>
-                <td>
-                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
-
-                    <a href="<?php echo esc_url(content_url('/ip-attempts.json')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
-                </td>
-            </tr>
-            <tr>
-                <td><code>email-attempts.json</code></td>
-                <td><?php echo esc_html__('Storico tentativi spam per email', 'digitalezen-cf7'); ?></td>
-                <td>
-                    <a href="<?php echo esc_url(admin_url('admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json')); ?>" class="button button-secondary" target="_blank">👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?></a>
-                    <a href="<?php echo esc_url(content_url('/email-attempts.json')); ?>" class="button" download>📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?></a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-
-
-    <hr>
-
-    <h2><?php esc_html_e('📊 Report spam bloccati (dati reali)', 'digitalezen-cf7'); ?></h2>
-
-    <canvas id="dz-cf7-chart" height="100" style="margin-bottom: 2em;"></canvas>
-
-    <?php
-    // Funzione per filtrare il log per fascia temporale
-    function dz_cf7_count_spam_by_range($minutes) {
-        $path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
-        if (!file_exists($path)) return 0;
-
-        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        $count = 0;
-        $now = time();
-
-        foreach ($lines as $line) {
-            $cols = str_getcsv($line);
-            if (!isset($cols[0])) continue;
-            $ts = strtotime($cols[0]);
-            if (($now - $ts) <= ($minutes * 60)) $count++;
-        }
-
-        return $count;
-    }
-
-    // Calcolo i blocchi per ogni intervallo
-    $data_report = [
-        esc_html__('24h', 'digitalezen-cf7')      => dz_cf7_count_spam_by_range(1440),
-        esc_html__('7 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(10080),
-        esc_html__('28 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(40320),
-        esc_html__('3 mesi', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(129600),
-        esc_html__('1 anno', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(525600),
-    ];
-
-    // Passaggio dati a JS
-    echo '<script>window.dz_cf7_chart_data = ' . json_encode(array_values($data_report)) . ';</script>';
-    echo '<script>window.dz_cf7_chart_labels = ' . json_encode(array_keys($data_report)) . ';</script>';
-    ?>
-
-    <h3><?php esc_html_e('🧾 Ultimi tentativi bloccati', 'digitalezen-cf7'); ?></h3>
-    <table class="widefat striped" style="max-width: 100%; margin-top: 1em;">
-        <thead>
-            <tr>
-                <th><?php esc_html_e('Data', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('Email', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('IP', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('Motivo', 'digitalezen-cf7'); ?></th>
-                <th><?php esc_html_e('Trigger', 'digitalezen-cf7'); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-        <?php
-        $path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
-        if (file_exists($path)) {
-            $lines = array_reverse(file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
-            $max = 30;
-            foreach (array_slice($lines, 0, $max) as $line) {
-                $cols = str_getcsv($line);
-                echo '<tr>';
-                foreach ($cols as $col) {
-                    echo '<td>' . esc_html($col) . '</td>';
-                }
-                echo '</tr>';
-            }
-        }
-        ?>
-        </tbody>
-    </table>
+	<h2><?php esc_html_e('📁 File generati dal plugin', 'digitalezen-cf7'); ?></h2>
+	<table class="widefat striped" style="margin-bottom: 2em;">
+	    <thead>
+	        <tr>
+	            <th><?php esc_html_e('File', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('Descrizione', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('Azioni', 'digitalezen-cf7'); ?></th>
+	        </tr>
+	    </thead>
+	    <tbody>
+	        <tr>
+	            <td><code>cf7-spam-log.csv</code></td>
+	            <td>
+	                <?php
+	                echo esc_html__(
+	                    'Log dei tentativi bloccati (data, email, IP, motivo, trigger)',
+	                    'digitalezen-cf7'
+	                );
+	                ?>
+	            </td>
+	            <td>
+	                <a href="<?php echo esc_url($log_file); ?>" class="button button-secondary" download>
+	                    📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?>
+	                </a>
+	            </td>
+	        </tr>
+	        <tr>
+	            <td><code>cf7-blacklist.json</code></td>
+	            <td>
+	                <?php
+	                echo esc_html__(
+	                    'Blacklist aggiornata da App Script (IP, email, domini, ecc.)',
+	                    'digitalezen-cf7'
+	                );
+	                ?>
+	            </td>
+	            <td>
+	                <a
+	                    href="<?php
+	                        echo esc_url(
+	                            admin_url(
+	                                'admin-ajax.php?action=dz_cf7_view_json&f=cf7-blacklist.json'
+	                            )
+	                        );
+	                    ?>"
+	                    class="button button-secondary" target="_blank">
+	                    👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?>
+	                </a>
+	                <a href="<?php echo esc_url($blacklist_file); ?>" class="button" download>
+	                    📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?>
+	                </a>
+	            </td>
+	        </tr>
+	        <tr>
+	            <td><code>block-ip.txt</code></td>
+	            <td>
+	                <?php
+	                echo esc_html__(
+	                    'IP bloccati temporaneamente (blocco soft, durata 10 minuti)',
+	                    'digitalezen-cf7'
+	                );
+	                ?>
+	            </td>
+	            <td>
+	                <a
+	                    href="<?php echo esc_url(content_url('/block-ip.txt')); ?>"
+	                    class="button button-secondary" target="_blank">
+	                    👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?>
+	                </a>
+	                <a href="<?php echo esc_url(content_url('/block-ip.txt')); ?>" class="button" download>
+	                    📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?>
+	                </a>
+	            </td>
+	        </tr>
+	        <tr>
+	            <td><code>ip-attempts.json</code></td>
+	            <td>
+	                <?php echo esc_html__('Storico tentativi spam per IP', 'digitalezen-cf7'); ?>
+	            </td>
+	            <td>
+	                <a
+	                    href="<?php
+	                        echo esc_url(
+	                            admin_url(
+	                                'admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json'
+	                            )
+	                        );
+	                    ?>"
+	                    class="button button-secondary" target="_blank">
+	                    👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?>
+	                </a>
+	                <a href="<?php echo esc_url(content_url('/ip-attempts.json')); ?>" class="button" download>
+	                    📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?>
+	                </a>
+	            </td>
+	        </tr>
+	        <tr>
+	            <td><code>email-attempts.json</code></td>
+	            <td>
+	                <?php echo esc_html__('Storico tentativi spam per email', 'digitalezen-cf7'); ?>
+	            </td>
+	            <td>
+	                <a
+	                    href="<?php
+	                        echo esc_url(
+	                            admin_url(
+	                                'admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json'
+	                            )
+	                        );
+	                    ?>"
+	                    class="button button-secondary" target="_blank">
+	                    👁️ <?php esc_html_e('Visualizza', 'digitalezen-cf7'); ?>
+	                </a>
+	                <a href="<?php echo esc_url(content_url('/email-attempts.json')); ?>" class="button" download>
+	                    📥 <?php esc_html_e('Download', 'digitalezen-cf7'); ?>
+	                </a>
+	            </td>
+	        </tr>
+	    </tbody>
+	</table>
 
 
-    <hr>
+	<hr>
 
-    <p style="margin-top: 2em; text-align: center; color: #666;">
-        <small>
-            <?php echo wp_kses_post(__('Powered by <a href="https://digitalezen.it" target="_blank" style="text-decoration: none;">DigitaleZen.it</a> 🚀', 'digitalezen-cf7')); ?>
-        </small>
-    </p>
+	<h2><?php esc_html_e('📊 Report spam bloccati (dati reali)', 'digitalezen-cf7'); ?></h2>
+
+	<canvas id="dz-cf7-chart" height="100" style="margin-bottom: 2em;"></canvas>
+
+	<?php
+	// Funzione per filtrare il log per fascia temporale
+	function dz_cf7_count_spam_by_range($minutes) {
+	    $path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
+	    if (!file_exists($path)) return 0;
+
+	    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	    $count = 0;
+	    $now = time();
+
+	    foreach ($lines as $line) {
+	        $cols = str_getcsv($line);
+	        if (!isset($cols[0])) continue;
+	        $ts = strtotime($cols[0]);
+	        if (($now - $ts) <= ($minutes * 60)) $count++;
+	    }
+
+	    return $count;
+	}
+
+	// Calcolo i blocchi per ogni intervallo
+	$data_report = [
+	    esc_html__('24h', 'digitalezen-cf7')      => dz_cf7_count_spam_by_range(1440),
+	    esc_html__('7 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(10080),
+	    esc_html__('28 giorni', 'digitalezen-cf7') => dz_cf7_count_spam_by_range(40320),
+	    esc_html__('3 mesi', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(129600),
+	    esc_html__('1 anno', 'digitalezen-cf7')   => dz_cf7_count_spam_by_range(525600),
+	];
+
+	// Passaggio dati a JS
+	echo '<script>window.dz_cf7_chart_data = ' . json_encode(array_values($data_report)) . ';</script>';
+	echo '<script>window.dz_cf7_chart_labels = ' . json_encode(array_keys($data_report)) . ';</script>';
+	?>
+
+	<h3><?php esc_html_e('🧾 Ultimi tentativi bloccati', 'digitalezen-cf7'); ?></h3>
+	<table class="widefat striped" style="max-width: 100%; margin-top: 1em;">
+	    <thead>
+	        <tr>
+	            <th><?php esc_html_e('Data', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('Email', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('IP', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('Motivo', 'digitalezen-cf7'); ?></th>
+	            <th><?php esc_html_e('Trigger', 'digitalezen-cf7'); ?></th>
+	        </tr>
+	    </thead>
+	    <tbody>
+	    <?php
+	    $path = wp_upload_dir()['basedir'] . '/cf7-logs/cf7-spam-log.csv';
+	    if (file_exists($path)) {
+	        $lines = array_reverse(file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
+	        $max = 30;
+	        foreach (array_slice($lines, 0, $max) as $line) {
+	            $cols = str_getcsv($line);
+	            echo '<tr>';
+	            foreach ($cols as $col) {
+	                echo '<td>' . esc_html($col) . '</td>';
+	            }
+	            echo '</tr>';
+	        }
+	    }
+	    ?>
+	    </tbody>
+	</table>
+
+
+	<hr>
+
+	<p style="margin-top: 2em; text-align: center; color: #666;">
+	    <small>
+	        <?php
+	        echo wp_kses_post(
+	            __(
+	                'Powered by <a href="https://digitalezen.it" target="_blank" '
+	                . 'style="text-decoration: none;">DigitaleZen.it</a> '
+	                . '🚀',
+	                'digitalezen-cf7'
+	            )
+	        );
+	        ?>
+	    </small>
+	</p>
 
 
 </div>


### PR DESCRIPTION
## Summary
- add WordPress style file headers
- sanitize globals and localize remaining strings
- format code per WordPress standards

## Testing
- `php -l digitalezen-cf7-antispam.php`
- `for f in includes/*.php templates/*.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68598d56a96c8326aa8178b700e3a9ff