### PR TITLE
Ensure all strings use i18n text domain

### DIFF
--- a/digitalezen-cf7-antispam.php
+++ b/digitalezen-cf7-antispam.php
@@ -9,7 +9,7 @@
  * Author: DigitaleZen
  * Author URI: https://digitalezen.it
  * License: MIT
- * Text Domain: digitalezen-cf7-antispam
+ * Text Domain: digitalezen-cf7
  */
 
 defined('ABSPATH') || exit;

--- a/includes/admin-dashboard.php
+++ b/includes/admin-dashboard.php
@@ -34,7 +34,7 @@ function dz_cf7_render_dashboard()
 {
 	// 📸 Banner e logo nella parte alta della dashboard
 	echo '<div style="text-align: center; padding: 20px 0;">';
-	echo '<img src="' . esc_url(DZ_CF7_URL . 'assets/img/banner2.png') . '" alt="Banner DigitaleZen" style="max-width: 100%; height: auto; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-bottom: 20px;">';
+        echo '<img src="' . esc_url(DZ_CF7_URL . 'assets/img/banner2.png') . '" alt="' . esc_attr__('Banner DigitaleZen', 'digitalezen-cf7') . '" style="max-width: 100%; height: auto; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); margin-bottom: 20px;">';
 	echo '</div>';
 
 	include DZ_CF7_DIR . 'templates/dashboard.php';

--- a/languages/digitalezen-cf7.pot
+++ b/languages/digitalezen-cf7.pot
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2025-06-23T17:39:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
-"X-Domain: digitalezen-cf7-antispam\n"
+"X-Domain: digitalezen-cf7\n"
 
 #. Plugin Name of the plugin
 #: digitalezen-cf7-antispam.php

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -67,7 +67,7 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 	    <li>
 	        <code>[honeypot spamcheck]</code>
 	        <a href="https://wordpress.org/plugins/contact-form-7-honeypot/" target="_blank" style="font-size: 0.9em; color: #0073aa; text-decoration: underline; margin-left: 6px;">
-	            (Richiede il plugin Honeypot for Contact Form 7)
+                <?php echo esc_html__('(Richiede il plugin Honeypot for Contact Form 7)', 'digitalezen-cf7'); ?>
 	        </a>
 	    </li>
 	    <li><code>[hidden timestamp default:get]</code></li>


### PR DESCRIPTION
## Summary
- use `esc_attr__()` for dashboard banner alt text
- translate Honeypot plugin notice
- align plugin header text domain with code
- update pot file domain

## Testing
- `php -l digitalezen-cf7-antispam.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654839902c8326b81c60aa0e1cf360