### PR TITLE
Fix WordPress code warnings

### DIFF
--- a/includes/admin-dashboard.php
+++ b/includes/admin-dashboard.php
@@ -45,11 +45,12 @@ add_action('admin_init', function () {
 	$action = isset($_GET['action']) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
 	$file   = isset($_GET['f']) ? sanitize_text_field( wp_unslash( $_GET['f'] ) ) : '';
 
-	if ($action === 'dz_cf7_view_json' && $file) {
-	    $_GET['f'] = $file;
-	    include_once DZ_CF7_DIR . 'includes/view-json.php';
-	    exit;
-	}
+        if ($action === 'dz_cf7_view_json' && $file) {
+            check_admin_referer('dz_cf7_view_json');
+            $_GET['f'] = $file;
+            include_once DZ_CF7_DIR . 'includes/view-json.php';
+            exit;
+        }
 });
 
 // 📊 Enqueue degli script solo nella pagina CF7 AntiSpam

--- a/includes/view-json.php
+++ b/includes/view-json.php
@@ -14,8 +14,9 @@ $whitelist = [
 ];
 
 $file_key = isset($_GET['f']) ? sanitize_text_field($_GET['f']) : '';
+check_admin_referer('dz_cf7_view_json');
 if (!isset($whitelist[$file_key])) {
-	http_response_code(403);
+        http_response_code(403);
     exit(esc_html__('⛔ Unauthorized access.', 'digitalezen-cf7-antispam'));
 }
 
@@ -27,5 +28,10 @@ if (!file_exists($file_path)) {
 }
 
 header("Content-Type: text/plain; charset=UTF-8");
-readfile($file_path);
+global $wp_filesystem;
+if (empty($wp_filesystem)) {
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+    WP_Filesystem();
+}
+echo $wp_filesystem->get_contents($file_path);
 exit;

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === DigitaleZen CF7 AntiSpam Shield ===
 Contributors: digitalezen, Riccardo Rosignoli  
 Donate link: https://digitalezen.it  
-Tags: contact form 7, spam, anti-spam, firewall, honeypot, blacklist, email protection, token, no captcha  
+Tags: contact form 7, spam, firewall, blacklist, honeypot
 Requires at least: 5.6  
 Tested up to: 6.8  
 Requires PHP: 7.4  
@@ -9,7 +9,7 @@ Stable tag: 1.0.0
 License: MIT  
 License URI: https://opensource.org/licenses/MIT  
 
-The ultimate protection for Contact Form 7: block spam, bots, and automated attacks using invisible honeypots, dynamic tokens, IP firewall, and real-time blacklist updates. No CAPTCHA required.
+The ultimate shield for Contact Form 7. Blocks spam with honeypots, tokens and a live blacklist—no CAPTCHA.
 
 == Description ==
 

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -116,11 +116,14 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 	            <td>
 	                <a
 	                    href="<?php
-	                        echo esc_url(
-	                            admin_url(
-	                                'admin-ajax.php?action=dz_cf7_view_json&f=cf7-blacklist.json'
-	                            )
-	                        );
+                                echo esc_url(
+                                    wp_nonce_url(
+                                        admin_url(
+                                            'admin-ajax.php?action=dz_cf7_view_json&f=cf7-blacklist.json'
+                                        ),
+                                        'dz_cf7_view_json'
+                                    )
+                                );
 	                    ?>"
 	                    class="button button-secondary" target="_blank">
                             👁️ <?php esc_html_e('View', 'digitalezen-cf7-antispam'); ?>
@@ -159,11 +162,14 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 	            <td>
 	                <a
 	                    href="<?php
-	                        echo esc_url(
-	                            admin_url(
-	                                'admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json'
-	                            )
-	                        );
+                                echo esc_url(
+                                    wp_nonce_url(
+                                        admin_url(
+                                            'admin-ajax.php?action=dz_cf7_view_json&f=ip-attempts.json'
+                                        ),
+                                        'dz_cf7_view_json'
+                                    )
+                                );
 	                    ?>"
 	                    class="button button-secondary" target="_blank">
                             👁️ <?php esc_html_e('View', 'digitalezen-cf7-antispam'); ?>
@@ -181,11 +187,14 @@ $blacklist_file = $upload_url . '/cf7-blacklist.json';
 	            <td>
 	                <a
 	                    href="<?php
-	                        echo esc_url(
-	                            admin_url(
-	                                'admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json'
-	                            )
-	                        );
+                                echo esc_url(
+                                    wp_nonce_url(
+                                        admin_url(
+                                            'admin-ajax.php?action=dz_cf7_view_json&f=email-attempts.json'
+                                        ),
+                                        'dz_cf7_view_json'
+                                    )
+                                );
 	                    ?>"
 	                    class="button button-secondary" target="_blank">
                             👁️ <?php esc_html_e('View', 'digitalezen-cf7-antispam'); ?>


### PR DESCRIPTION
## Summary
- add nonce verification for JSON viewer
- use WP_Filesystem instead of readfile
- append nonce to dashboard viewer URLs
- shorten and reduce tags in README

## Testing
- `find . -name '*.php' -print | xargs -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68660a2321a88326ae2798c9f4c72f21